### PR TITLE
Moved to .NET 8

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] .NET version: 7.0, 7.0-bullseye-slim, 7.0-jammy, 6.0, 6.0-bullseye-slim, 6.0-jammy, 6.0-focal
-ARG VARIANT="7.0-jammy"
+ARG VARIANT="8.0"
 FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,7 @@
       "dockerfile": "./Dockerfile",
       "context": ".",
       "args": {
-        // version: 7.0, 7.0-bullseye-slim, 7.0-jammy, 6.0, 6.0-bullseye-slim, 6.0-jammy, 6.0-focal
-        "VARIANT": "7.0"
+        "VARIANT": "8.0"
       }
     },
   


### PR DESCRIPTION
I was having trouble identifying a minimal set of dependencies for Polyglot Notebooks in CodeSpaces and came across this repo. I imagine this isn't being maintained anymore, but I wanted to update the version from 7 to 8 so it at least runs under the current requirements for Polyglot Notebooks. This repo also will then serve as a very minimal example of configuration for a Polyglot repo's CodeSpaces.